### PR TITLE
Fix - Modify Playlist E2E Test Fails for Song Not Found

### DIFF
--- a/e2e/test/pages/song-details-component.ts
+++ b/e2e/test/pages/song-details-component.ts
@@ -27,6 +27,10 @@ class SongDetailsComponent {
         await (await this.getSearchResultTitleElementBySongTitle(title)).click();
     }
 
+    async getSearchResultSongTitleByIndex(index: number) {
+        return await this.searchResultSongTitleElements[index].getText();
+    }
+
     async waitForSearchResults() {
         await browser.waitUntil(async () => {
             return (await this.searchResultSongTitleElements).length > 0;

--- a/e2e/test/specs/modify-playlist.ts
+++ b/e2e/test/specs/modify-playlist.ts
@@ -41,7 +41,7 @@ suite('modify playlist flows', function () {
 
         console.log('Select the correct (related) known song.');
 
-        const modifiedSongTitle = 'Twilight vs Breathe (feat. HALIENE & Matthew Steeper) - Jack Trades Remix';
+        const modifiedSongTitle = await songDetailsComponent.getSearchResultSongTitleByIndex(0);
         await songDetailsComponent.clickSearchResultRowByTitle(modifiedSongTitle);
 
         console.log('Import the modified playlist into Spotify.');


### PR DESCRIPTION
* Made the test less fragile by relying on the first search result rather than a specific result (that no longer exists).