### PR TITLE
fix: csv with spaces not handled

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.ts]
+indent_size = 4
 quote_type = single
 
 [*.md]

--- a/e2e/test/assets/playlists/CsvWithSpaces.csv
+++ b/e2e/test/assets/playlists/CsvWithSpaces.csv
@@ -1,0 +1,5 @@
+Title, Artist
+Electric Love [Oliver Remix], BØRNS
+XXX 88, MØ
+Twilight vs Breathe (Jack Trades Remix), Adam K &amp; Soha
+No Place, Rüfüs Du Sol

--- a/src/app/csvPlaylist.spec.ts
+++ b/src/app/csvPlaylist.spec.ts
@@ -48,5 +48,17 @@ describe('CsvPlaylist', () => {
             const songs = playlist.getSongs();
             expect(songs.length).toEqual(2);
         });
+
+        it('should handle csv with spaces', () => {
+            const csv =
+                'Title, Artist\n' +
+                'Some Song, Some Artist';
+
+            const playlist = new CsvPlaylist(csv, 'Unit Test - CSV With Spaces Playlist');
+            const songs = playlist.getSongs();
+            expect(songs.length).toEqual(1);
+            expect(songs[0].title).toEqual('Some Song');
+            expect(songs[0].artist).toEqual('Some Artist');
+        });
     });
 });

--- a/src/app/csvPlaylist.ts
+++ b/src/app/csvPlaylist.ts
@@ -17,8 +17,8 @@ export class CsvPlaylist implements Playlist {
     const options: ParseConfig = {
       header: true,
       skipEmptyLines: true,
-      transformHeader: header => header.toUpperCase(),
-      transform: value => decode(value),
+      transformHeader: header => header.trim().toUpperCase(),
+      transform: value => decode(value.trim()),
     };
 
     this.csv = parse(playlistCsv, options);


### PR DESCRIPTION
* Updated the editor config to use 4 spaces for TS (to keep code style consistent).
* Added a test CSV file to assets for manual testing.
* Added a unit test that reproduces the issue.
* Added trim calls to the CSV parser's header and value transforms.

Refs: #221