### PR TITLE
extra fields in spotify query

### DIFF
--- a/src/app/csvPlaylist.ts
+++ b/src/app/csvPlaylist.ts
@@ -41,7 +41,7 @@ export class CsvPlaylist implements Playlist {
     if (CsvPlaylist.songs.length === 0) {
       for (const songData of this.csv.data) {
         // tslint:disable-next-line:no-string-literal
-        CsvPlaylist.songs.push({ title: songData['TITLE'], artist: songData['ARTIST'] });
+        CsvPlaylist.songs.push({ title: songData['TITLE'], artist: songData['ARTIST'], album: songData['ALBUM'] || "", isrc: songData['ISRC'] || "" });
       }
     }
 

--- a/src/app/song-details/song-details.component.ts
+++ b/src/app/song-details/song-details.component.ts
@@ -38,7 +38,7 @@ export class SongDetailsComponent implements OnInit {
   }
 
   private searchForRelated() {
-    this.spotifyService.loadPageOfSongs(this.song.title, this.song.artist, 1).then(songs => {
+    this.spotifyService.loadPageOfSongs(this.song.title, this.song.artist, 1, this.song.album, this.song.isrc).then(songs => {
       if (songs) {
         this.relatedSongs = songs;
       }

--- a/src/app/song.ts
+++ b/src/app/song.ts
@@ -1,6 +1,8 @@
 export interface Song {
   title: string;
   artist: string;
+  album?: string;
+  isrc?: string;
   uri?: string;
   previewUrl?: string;
   externalUrl?: string;

--- a/src/app/spotify.service.ts
+++ b/src/app/spotify.service.ts
@@ -86,7 +86,7 @@ export class SpotifyService {
 
     console.time('loadSongData');
     for (const song of songs) {
-      const searchResults = this.searchForSong(song.title, song.artist);
+      const searchResults = this.searchForSong(song.title, song.artist, song.album, song.isrc);
       searchResults.then((spotifySong) => {
         song.title = spotifySong.title;
         song.artist = spotifySong.artist;
@@ -136,9 +136,11 @@ export class SpotifyService {
     });
   }
 
-  loadPageOfSongs(title: string, artist: string, pageNumber: number): Promise<Song[] | null> {
+  loadPageOfSongs(title: string, artist: string, pageNumber: number, album: string, isrc: string): Promise<Song[] | null> {
     return new Promise<Song[]>(resolve => {
-      const query = `"${title}" artist:"${artist}"`;
+      let query = `"${title}" artist:"${artist}"`;
+      if (album) query+= ` album:${album}`;
+      if (isrc)  query+= ` isrc:${isrc}`;
       const limit = 10;
       const offset = (pageNumber - 1) * limit;
 
@@ -160,9 +162,11 @@ export class SpotifyService {
     });
   }
 
-  private searchForSong(title: string, artist: string): Promise<Song> {
+  private searchForSong(title: string, artist: string, album: string, isrc: string): Promise<Song> {
     return new Promise<Song>(resolve => {
-      const query = `${title} artist:${artist}`;
+      let query = `${title} artist:${artist}`;
+      if (album) query+= ` album:${album}`;
+      if (isrc)  query+= ` isrc:${isrc}`;
       this.spotifyWebApi.searchTracks(query, {limit: 1}).then((data) => {
         const song: Song = {artist, title};
         if (data.tracks.total > 0) {


### PR DESCRIPTION
Added the possibility to have `ALBUM` & `ISRC` columns in csv files, and use these fields in the query in the spotify search api.